### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 CJADSLKeyPath is a easy to use Category for accessing values with a special keyPath 
 
 ##Installation
-Just drag&drop the ```NSObject+DSLKeyPath.h.h``` file in your XCode Project. 
+Just drag&drop the ```NSObject+DSLKeyPath.h.h``` file in your Xcode Project. 
 For global usage you can import the ```NSObject+DSLKeyPath.h.h``` in your projects ```-Prefix.pch``` file.
 
 ##Usage


### PR DESCRIPTION
This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
